### PR TITLE
Updated default metric keys returned by getMeasures and getMeasuresHi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.1.0
+ - Updated default measures list to match sonarqube / sonarcloud main dashboard metrics.
+ - Added capability to request metrics for a user defined metricKeys list.
+
 ## Version 1.0.0
 - Initial release
 - SonarqubeInstance :

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $projects = $instance->getProjects();
 ### Manage a single Sonarqube project
 The **SonarqubeProject** class allows creation of a new sonarqube project or metadata / measures extraction from an existing sonarqube project.
 
+#### Create sonarqube project
 ```
 require '../vendor/autoload.php';
 
@@ -49,10 +50,20 @@ $project = new SonarqubeProject($api, $projectKey);
 if (!$project->exists()) {
   $project->create('Test Project From Api', 'public', 'testapi');
 }
+```
 
+#### Get projet measures
+Get default list of measures. Without any parameter, the functions return mesures for the following metric keys : **alert_status,bugs,reliability_rating,vulnerabilities,security_rating,code_smells,sqale_rating,duplicated_lines_density,coverage,ncloc,ncloc_language_distribution,reliability_remediation_effort,security_remediation_effort** . Metric keys list match the one used by Sonarqube to display the project dashboard.
+```
 $measures = $project->getMeasures();
-
 $measuresHistory = $project->getMeasuresHistory('2019-06-45');
+```
+
+To customize the measures returned by the function, add the list of desired metric keys :
+
+```
+$measures = $project->getMeasures('sqale_index');
+$measuresHistory = $project->getMeasuresHistory('2019-06-45', 'sqale_index');
 ```
 
 ### Manage users, groups, and permissions

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "forgeqc/sonarqube-api-client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "library",
   "description": "A simple PHP client for sonarqube and sonarcloud.io API",
   "keywords": ["sonarqube","sonarcloud","api","client"],

--- a/src/SonarqubeProject.php
+++ b/src/SonarqubeProject.php
@@ -66,11 +66,16 @@ class SonarqubeProject {
   }
 
   //Retrieve Sonarqube project measures
-  public function getMeasures() {
+  public function getMeasures($metricKeys=null) {
     $projects_measures = array();
 
     //Extract the project quality measures from sonarqube
-    $response = $this->httpclient->request('GET', 'measures/component?metricKeys=coverage,sqale_index,sqale_rating,bugs,reliability_remediation_effort,security_rating,vulnerabilities,security_remediation_effort&component='. $this->key);
+    if(isset($metricKeys)) {
+      $response = $this->httpclient->request('GET', 'measures/component?metricKeys='.$metricKeys.'&component='. $this->key);
+    }
+    else {
+      $response = $this->httpclient->request('GET', 'measures/component?metricKeys=alert_status,bugs,reliability_rating,vulnerabilities,security_rating,code_smells,sqale_rating,duplicated_lines_density,coverage,ncloc,ncloc_language_distribution,reliability_remediation_effort,security_remediation_effort&component='. $this->key);
+    }
     $sonarqubeProjectsMetrics = json_decode($response->getBody(), true);
 
     //Parse measures and inject in result array
@@ -84,13 +89,18 @@ class SonarqubeProject {
   }
 
   //Retrieve Sonarqube project measures
-  public function getMeasuresHistory($date) {
+  public function getMeasuresHistory($date, $metricKeys=null) {
     //Check if date is set and valid or return HTTP/400 Bad Request error
     if(preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/",$date)) {
       $projects_measures = array();
 
       //Extract the project quality measures from sonarqube
-      $response = $this->httpclient->request('GET', 'measures/search_history?metrics=coverage,sqale_index,sqale_rating,bugs,reliability_remediation_effort,security_rating,vulnerabilities,security_remediation_effort&component='. $this->key.'&from='.$date);
+      if(isset($metricKeys)) {
+        $response = $this->httpclient->request('GET', 'measures/search_history?metrics='.$metricKeys.'&component='. $this->key.'&from='.$date);
+      }
+      else {
+        $response = $this->httpclient->request('GET', 'measures/search_history?metrics=alert_status,bugs,reliability_rating,vulnerabilities,security_rating,code_smells,sqale_rating,duplicated_lines_density,coverage,ncloc,ncloc_language_distribution,reliability_remediation_effort,security_remediation_effort&component='. $this->key.'&from='.$date);
+      }
       $sonarqubeProjectsMetrics = json_decode($response->getBody(), true);
 
       //Parse measures and inject in result array

--- a/tests/SonarqubeProjectTest.php
+++ b/tests/SonarqubeProjectTest.php
@@ -87,9 +87,12 @@ class SonarqubeProjectTest extends TestCase
       $this->assertArrayHasKey('reliability_remediation_effort', $measures);
       $this->assertArrayHasKey('security_rating', $measures);
       $this->assertArrayHasKey('vulnerabilities', $measures);
-      $this->assertArrayHasKey('sqale_index', $measures);
+      $this->assertArrayHasKey('sqale_rating', $measures);
       $this->assertArrayHasKey('security_remediation_effort', $measures);
       $this->assertArrayHasKey('coverage', $measures);
+
+      $measuresCustom = $project->getMeasures('sqale_index');
+      $this->assertArrayHasKey('sqale_index', $measuresCustom);
   }
 
   //Test sonarqube project measures history extraction with valid date parameter
@@ -109,9 +112,12 @@ class SonarqubeProjectTest extends TestCase
       $this->assertArrayHasKey('reliability_remediation_effort', $measures);
       $this->assertArrayHasKey('security_rating', $measures);
       $this->assertArrayHasKey('vulnerabilities', $measures);
-      $this->assertArrayHasKey('sqale_index', $measures);
+      $this->assertArrayHasKey('sqale_rating', $measures);
       $this->assertArrayHasKey('security_remediation_effort', $measures);
       $this->assertArrayHasKey('coverage', $measures);
+
+      $measuresCustom = $project->getMeasuresHistory('2019-01-01', 'sqale_index');
+      $this->assertArrayHasKey('sqale_index', $measuresCustom);
   }
 
     //Test sonarqube project measures history extraction with wrong date parameter


### PR DESCRIPTION
- Updated default measures list to match sonarqube / sonarcloud main dashboard metrics.
- Added capability to request metrics for a user defined metricKeys list.